### PR TITLE
Fix ottrpal docker image "ottrpal not found"

### DIFF
--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -88,7 +88,7 @@ jobs:
 
   render-tocless:
     name: Render TOC-less version for Leanpub or Coursera
-    needs: [render-bookdown]
+    needs: [yaml-check, render-bookdown]
     runs-on: ubuntu-latest
     container:
       image: ${{needs.yaml-check.outputs.rendering_docker_image}}


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?

We have to have the tocless job require yaml-check to be run because that is how the docker image is specified. 

This will fix this. I double checked this is not an error that is in the main OTTR template: https://github.com/jhudsl/OTTR_Template/blob/2a35821ca73ae3f47cd673ef97846acc6ea9e6ca/.github/workflows/render-all.yml#L91C1-L91C24

Not sure how this was introduced. 

